### PR TITLE
Abort translation on parse errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,69 @@
+version: 2.1
+
+orbs:
+
+executors:
+  ruby_containter:
+    docker:
+      - image: circleci/ruby:2.5
+        environment:
+          RAILS_ENV: test
+
+commands:
+  bundle_install:
+    steps:
+      - restore_cache:
+          name: Restore Bundler Gemfile cache
+          keys:
+            - bundler-packages-v1-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Bundle Install
+          command: |
+            bundle install --jobs=4 --retry=3 --path=./vendor/bundle --frozen
+      - save_cache:
+          name: Save Bundler Package Cache
+          key: bundler-packages-v1-{{ checksum "Gemfile.lock" }}
+          paths:
+            - ./vendor/bundle
+  rake_test:
+    steps:
+      - run:
+          name: Ruby Tests
+          command: |
+            bundle exec rake test
+      - store_test_results:
+          # Should look like the directory passed to the JUnitReporter, minus
+          # the final "minitest" directory
+          path: "tmp/test_results"
+
+jobs:
+  build:
+    parallelism: 1
+    executor: ruby_containter
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - checkout
+      - bundle_install
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+  test:
+    parallelism: 1
+    executor: ruby_containter
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - bundle_install
+      - rake_test
+
+workflows:
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camel_patrol (1.0.1)
+    camel_patrol (1.1.1)
       railties (>= 4.1.0, < 6.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    ansi (1.5.0)
     arel (9.0.0)
     builder (3.2.3)
     concurrent-ruby (1.0.5)
@@ -69,6 +70,11 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    minitest-reporters (1.4.3)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -100,6 +106,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.5.0)
+    ruby-progressbar (1.11.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -122,6 +129,7 @@ DEPENDENCIES
   bundler (~> 1.10)
   camel_patrol!
   minitest
+  minitest-reporters
   rails (~> 5.1)
   rake (~> 10.0)
 

--- a/camel_patrol.gemspec
+++ b/camel_patrol.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest-reporters"
 end

--- a/lib/camel_patrol/middleware.rb
+++ b/lib/camel_patrol/middleware.rb
@@ -17,14 +17,17 @@ module CamelPatrol
     def underscore_params(env)
       if ::Rails::VERSION::MAJOR < 5
         env["action_dispatch.request.request_parameters"].deep_transform_keys!(&:underscore)
-      else
-        request_body = JSON.parse(env["rack.input"].read)
-        request_body.deep_transform_keys!(&:underscore)
-        req = StringIO.new(request_body.to_json)
-
-        env["rack.input"] = req
-        env["CONTENT_LENGTH"] = req.length
+        return
       end
+
+      if !(request_body = safe_json_parse(env["rack.input"].read))
+        return
+      end
+
+      request_body.deep_transform_keys!(&:underscore)
+      req = StringIO.new(request_body.to_json)
+      env["rack.input"] = req
+      env["CONTENT_LENGTH"] = req.length
     end
 
     def camelize_response(response)

--- a/lib/camel_patrol/version.rb
+++ b/lib/camel_patrol/version.rb
@@ -1,3 +1,3 @@
 module CamelPatrol
-  VERSION = "1.0.1"
+  VERSION = "1.1.1"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,13 @@ require 'camel_patrol'
 require "rails/version"
 
 require 'minitest/autorun'
+require "minitest/reporters"
+
+Minitest::Reporters.use!(
+  [
+    Minitest::Reporters::DefaultReporter.new,
+    # This path should match up, save for the last directory, with the value
+    # in `store_test_results` and `store_artifacts` in .circleci/config.yml
+    Minitest::Reporters::JUnitReporter.new("tmp/test_results/minitest"),
+  ],
+)


### PR DESCRIPTION
For requests, we should abort translating key format if a parsing error
occurs due to invalid json. Let the request continue untouched, similar
to the scenario when content-type header is missing

It shouldn't be this middleware's responsibility to deal with invalid
json. The app server can handle these scenarios on a case by case basis

Making this change b/c HSP is noisily alerting for mal intentioned requests, and we'd like to be able to address specific noisy error alerts at the app level

https://www.pivotaltracker.com/story/show/176519829
[#176519829]