### PR TITLE
Make it work with rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in camel_patrol.gemspec
 gemspec
 
-gem 'rails', '~> 5.1'
+gem 'rails', '~> 7.0'

--- a/camel_patrol.gemspec
+++ b/camel_patrol.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 4.1.0", "< 6.0"
+  spec.add_dependency "railties", ">= 5", "< 8"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/camel_patrol/middleware.rb
+++ b/lib/camel_patrol/middleware.rb
@@ -15,11 +15,6 @@ module CamelPatrol
     private
 
     def underscore_params(env)
-      if ::Rails::VERSION::MAJOR < 5
-        env["action_dispatch.request.request_parameters"].deep_transform_keys!(&:underscore)
-        return
-      end
-
       if !(request_body = safe_json_parse(env["rack.input"].read))
         return
       end


### PR DESCRIPTION
makes gem work with rails 7; currently getting:

```
Bundler could not find compatible versions for gem "railties":
  In snapshot (Gemfile.lock):
    railties (= 7.0.3.1)

  In Gemfile:
    camel_patrol (= 1.1.1) was resolved to 1.1.1, which depends on
      railties (< 6.0, >= 4.1.0)

    rails (~> 7.0.2, >= 7.0.2.4) was resolved to 7.0.3.1, which depends on
      railties (= 7.0.3.1)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```